### PR TITLE
shop_detail(店舗情報の表示の実装)

### DIFF
--- a/components/timeline/post/components/shop_detail/shop_detail.jsx
+++ b/components/timeline/post/components/shop_detail/shop_detail.jsx
@@ -1,7 +1,7 @@
 import style from './shop_detail.module.scss';
 
 export const Shop_Detail = (props) => {
-    const {park, payments, seatTypes, notSmokingSeat, phoneNumber, adress} = props
+    const {open, park, payments, seatTypes, notSmokingSeat, phoneNumber, adress} = props
 
     return (
         <div className={style.shop_detail}>
@@ -9,7 +9,11 @@ export const Shop_Detail = (props) => {
             <div className={style.contents}>
                 <div>    
                     <b>営業時間</b><br />
-                    <div className={style.table_data}>月～木　16:00~0:00</div>
+                    {open.map((time) => (
+                        <div key={time} className={style.table_data}>
+                            {time}
+                        </div>
+                    ))}
                 </div>
                 <div>
                     <b>駐車場</b><br />

--- a/components/timeline/post/components/shop_detail/shop_detail.jsx
+++ b/components/timeline/post/components/shop_detail/shop_detail.jsx
@@ -1,0 +1,49 @@
+import style from './shop_detail.module.scss';
+
+export const Shop_Detail = (props) => {
+    const {park, payments, seatTypes, notSmokingSeat, phoneNumber, adress} = props
+
+    return (
+        <div className={style.shop_detail}>
+            <h2 className={style.title}>店舗情報</h2>
+            <div className={style.contents}>
+                <div>    
+                    <b>営業時間</b><br />
+                    <div className={style.table_data}>月～木　16:00~0:00</div>
+                </div>
+                <div>
+                    <b>駐車場</b><br />
+                    <div className={style.table_data}>{park}</div>
+                </div>
+                <div>
+                    <b>支払方法</b><br />
+                    {payments.map((payment) => (
+                        <div key={payment} className={style.table_data}>
+                            {payment}
+                        </div>
+                    ))}
+                </div>
+                <div>
+                    <b>座席情報</b><br />
+                    {seatTypes.map((seatType) => (
+                        <div key={seatType} className={style.table_data}>
+                            {seatType}
+                        </div>
+                    ))}
+                </div>
+                <div>
+                    <b>禁煙席</b><br />
+                    <div className={style.table_data}>{notSmokingSeat}</div>
+                </div>
+                <div>
+                    <b>連絡先</b><br />
+                    <div className={style.table_data}>{phoneNumber}</div>
+                </div>
+                <div>
+                    <b>住所</b><br />
+                    <div className={style.table_data}>{adress}</div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/components/timeline/post/components/shop_detail/shop_detail.module.scss
+++ b/components/timeline/post/components/shop_detail/shop_detail.module.scss
@@ -1,0 +1,18 @@
+.shop_detail {
+    width: 45%;
+}
+
+.title {
+  margin-left: 30px;
+}
+
+.contents {
+  background-color: rgb(246, 249, 252);
+  margin: 10px 20px;
+  border-radius: 10px;
+  padding: 5px;
+}
+
+.table_data{
+  text-indent: 1em;
+}

--- a/components/timeline/post/post.jsx
+++ b/components/timeline/post/post.jsx
@@ -7,7 +7,7 @@ import { Shop_Detail } from './components/shop_detail/shop_detail';
 import { getStaticProps } from '../../../pages/timeline';
 
 export const Post = (props) => {
-    const { name, genre, purpose, park, payments, seatTypes, notSmokingSeat, phoneNumber, adress } = props;
+    const { name, genre, purpose, open, park, payments, seatTypes, notSmokingSeat, phoneNumber, adress } = props;
     const [anchorEl, setAnchorEl] = useState(null);
 
     const handleClick = useCallback(() => {
@@ -43,7 +43,8 @@ export const Post = (props) => {
                 <div>
                     <div className={style.cardPosition}>
                         <UserComment />
-                        <Shop_Detail 
+                        <Shop_Detail
+                            open={open}
                             park={park}
                             payments={payments}
                             seatTypes={seatTypes}

--- a/components/timeline/post/post.jsx
+++ b/components/timeline/post/post.jsx
@@ -3,9 +3,11 @@ import LocalBarIcon from '@material-ui/icons/LocalBar';
 import React, { useCallback, useState } from 'react';
 import { Button } from '@material-ui/core';
 import { UserComment } from './components/user-comment/user-comment';
+import { Shop_Detail } from './components/shop_detail/shop_detail';
+import { getStaticProps } from '../../../pages/timeline';
 
 export const Post = (props) => {
-    const { name , genre, purpose} = props;
+    const { name, genre, purpose, park, payments, seatTypes, notSmokingSeat, phoneNumber, adress } = props;
     const [anchorEl, setAnchorEl] = useState(null);
 
     const handleClick = useCallback(() => {
@@ -41,8 +43,14 @@ export const Post = (props) => {
                 <div>
                     <div className={style.cardPosition}>
                         <UserComment />
-                        <UserComment />
-                        <UserComment />
+                        <Shop_Detail 
+                            park={park}
+                            payments={payments}
+                            seatTypes={seatTypes}
+                            notSmokingSeat={notSmokingSeat}
+                            phoneNumber={phoneNumber}
+                            adress={adress}
+                        />
                     </div>
                     <div className={style.shopdetailCloseButton} onClick={handleClose}>閉じる↑</div>
                 </div>

--- a/pages/timeline.jsx
+++ b/pages/timeline.jsx
@@ -42,6 +42,12 @@ const Timeline = ({shopdatas}) => {
                         name={shopdata.name}
                         genre={shopdata.tag.genre}
                         purpose={shopdata.tag.purpose}
+                        park={shopdata.park}
+                        payments={shopdata.payment}
+                        seatTypes={shopdata.seatType}
+                        notSmokingSeat={shopdata.notSmokingSeat}
+                        phoneNumber={shopdata.phoneNumber}
+                        adress={shopdata.adress}
                     />
                 </div>
             ))}

--- a/pages/timeline.jsx
+++ b/pages/timeline.jsx
@@ -42,6 +42,7 @@ const Timeline = ({shopdatas}) => {
                         name={shopdata.name}
                         genre={shopdata.tag.genre}
                         purpose={shopdata.tag.purpose}
+                        open={shopdata.open}
                         park={shopdata.park}
                         payments={shopdata.payment}
                         seatTypes={shopdata.seatType}


### PR DESCRIPTION
kanjiデータベース内のshopdatasコレクションの店舗ごとのデータに、営業時間に関する項目"open"、メニューに関する項目"menu"を追加した。
shopdatasから店舗情報を取得して表示する機能を以下のファイルを作成/変更して実装した。
・pages/timeline.jsx
・components/timeline/post/post.jsx
・components/timeline/post/components/shop_detail/shop_detail.jsx
・components/timeline/post/components/shop_detail/shop_detail.module.scss