### PR TITLE
サイドバーのタグ検索欄に入力した際に見出しにも入力内容が表示されるバグの修正

### DIFF
--- a/pages/timeline.jsx
+++ b/pages/timeline.jsx
@@ -140,7 +140,7 @@ const Timeline = ({shopdatas,plandatas,commentdatas,picturedatas}) => {
                 })}
                 <div className={style.sidebar}>
                 <div className={style.box}>
-                    <div className={style.label}><LocalOfferIcon className={style.icon} />タグ{tag}</div>
+                    <div className={style.label}><LocalOfferIcon className={style.icon} />タグ</div>
                     <label htmlFor="tag" style={{width:"220px"}}>
                         <Tag Select={SelectTag} item={tag} id_str="tag"/>
                     </label>


### PR DESCRIPTION
サイドバーのタグ検索欄に入力した内容がタグ検索欄の見出しにも表示されていたのを修正。